### PR TITLE
Bugfix: change equipment name property type to string

### DIFF
--- a/equipment.ts
+++ b/equipment.ts
@@ -1,6 +1,6 @@
 export class Equipment {
   constructor(
-    public name: number,
+    public name: string,
     public type: string,
     public attack: number,
     public defense: number,


### PR DESCRIPTION
The type of the `name` property has been corrected from `number` to `string`, ensuring that equipment names are handled as intended.