### PR TITLE
Bugfix: ensure setType method returns `this`  for proper method chaining

### DIFF
--- a/equipment-builder.ts
+++ b/equipment-builder.ts
@@ -14,7 +14,7 @@ export class EquipmentBuilder {
 
   setType(type: string): this {
     this.type = type;
-    return type;
+    return this;
   }
 
   setAttack(attack: number): this {


### PR DESCRIPTION
Small fix to the `EquipmentBuilder` class. The `setType` method now correctly returns the builder instance (`this`) instead of the `type` string, ensuring method chaining works as expected.