### PR TITLE
Bugfix: ensure excalibur's stats make sense with its intent in the game

### DIFF
--- a/equipment-director.ts
+++ b/equipment-director.ts
@@ -8,7 +8,8 @@ export class EquipmentDirector {
     return this.builder
       .setName("Excalibur")
       .setType("Sword")
-      .setDefense(100)
+      .setAttack(80)
+      .setDefense(5)
       .setMagic(5)
       .build();
   }


### PR DESCRIPTION
This PR updates the configuration for the "Excalibur" equipment in the `EquipmentDirector` class. The change adjusts the balance of the item's attributes to better reflect its intended role.

Attribute adjustments for "Excalibur":

* Changed the configuration to set the attack value to 80 and reduced the defense value from 100 to 5 in the `EquipmendDirector`.